### PR TITLE
Fix bug on JSX compiler code generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rung-cli",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "Command line interface for Rung",
   "main": "./dist/vm.js",
   "bin": {

--- a/src/compiler.js
+++ b/src/compiler.js
@@ -1,5 +1,5 @@
 import dasherize from 'dasherize';
-import {
+import R, {
     T,
     always,
     cond,
@@ -65,9 +65,14 @@ export function compileHTML(tag, props, ...children) {
         [T, identity]
     ])(tag);
 
+    const render = cond([
+        [item => R.type(item) === 'Array', join('')],
+        [T, identity]
+    ]);
+
     return children.length === 0
         ? `<${filteredTag}${compileProps(props)} />`
-        : `<${filteredTag}${compileProps(props)}>${children.join('')}</${filteredTag}>`;
+        : `<${filteredTag}${compileProps(props)}>${children.map(render).join('')}</${filteredTag}>`;
 }
 
 /**

--- a/test/compiler.spec.js
+++ b/test/compiler.spec.js
@@ -73,6 +73,23 @@ describe('compiler.js', () => {
                 .then(result => {
                     expect(result).to.equals('<div><span>alert();</span>Alerting?</div>');
                 });
-        })
+        });
+
+        it('should correctly join array elements', () => {
+            const source = compileES6(`
+                const component = (
+                    <div>
+                        { [1, 2, 3].map(num => <b>{ num }</b>) }
+                    </div>
+                );
+
+                export default { extension: () => component };
+            `);
+
+            return runAndGetAlerts({ name: 'test-jsx-array', source }, {})
+                .then(result => {
+                    expect(result).to.equals('<div><b>1</b><b>2</b><b>3</b></div>');
+                });
+        });
     })
 });


### PR DESCRIPTION
```jsx
<div>{ [1, 2, 3].map(x => <b>x</b>) }</div>
```

... was being rendered as:

```html
<div><b>1</b>,<b>2</b>,<b>3</b></div>
```

With this, fix, it will be correctly taken as:

```html
<div><b>1</b><b>2</b><b>3</b></div>
```