### PR TITLE
i18n on CLI

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rung-cli",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Command line interface for Rung",
   "main": "./dist/vm.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "license": "MIT",
   "scripts": {
     "start": "node ./dist/index.js",
-    "compile": "babel ./src -d ./dist --source-maps && cp ./src/packages.txt ./dist",
+    "compile": "babel ./src -d ./dist --source-maps",
     "lint": "xo src/**",
     "fix-lint": "xo src/** --fix",
     "prepublish": "npm run compile",
@@ -31,6 +31,7 @@
     "handlebars": "^4.0.8",
     "jszip": "^3.1.3",
     "moment": "^2.18.1",
+    "os-locale": "^2.0.0",
     "prettyjson": "^1.2.1",
     "ramda": "0.23.0",
     "read": "^1.0.7",

--- a/src/build.js
+++ b/src/build.js
@@ -36,7 +36,7 @@ const filterProjectFiles = filter(contains(__, projectFiles));
 function appendLocales(files) {
     return fs.lstatAsync('locales')
         .then(lstat => lstat.isDirectory() ? fs.readdirAsync('locales') : [])
-        .then(filter(test(/^[a-z]{2}_[A-Z]{2}\.json$/)))
+        .then(filter(test(/^[a-z]{2}_[A-Z]{2,3}\.json$/)))
         .filter(filename => fs.readFileAsync(path.join('locales', filename))
             .then(pipe(JSON.parse, item => type(item) === 'Object'))
             .catchReturn(false))

--- a/src/build.js
+++ b/src/build.js
@@ -36,7 +36,7 @@ const filterProjectFiles = filter(contains(__, projectFiles));
 function appendLocales(files) {
     return fs.lstatAsync('locales')
         .then(lstat => lstat.isDirectory() ? fs.readdirAsync('locales') : [])
-        .then(filter(test(/^[a-z]{2}_[A-Z]{2,3}\.json$/)))
+        .then(filter(test(/^[a-z]{2}(_[A-Z]{2,3})?\.json$/)))
         .filter(filename => fs.readFileAsync(path.join('locales', filename))
             .then(pipe(JSON.parse, item => type(item) === 'Object'))
             .catchReturn(false))

--- a/src/cli.js
+++ b/src/cli.js
@@ -32,7 +32,7 @@ function cli(args) {
 }
 
 cli(yargs
-    .usage('Usage: $0 [init|build|run|publish|readme]')
+    .usage('Usage: $0 [init|build|run|publish|readme|db]')
     .command('init', 'Initialize a blank extension project')
     .command('build', 'Generate a .rung package')
     .command('publish', 'Publishes the extension to the Rung store')

--- a/src/compiler.js
+++ b/src/compiler.js
@@ -3,6 +3,7 @@ import {
     T,
     always,
     cond,
+    contains,
     equals,
     identity,
     ifElse,
@@ -51,6 +52,21 @@ function compileProps(props) {
 }
 
 /**
+ * Compiles a self-closing tag, dealing with elements that may or not be
+ * self-closing
+ *
+ * @param {String} tag - JSX component name
+ * @param {Object} props - Element properties
+ */
+function compileSelfClosingTag(tag, props) {
+    const compiledProps = compileProps(props);
+
+    return contains(tag, ['br', 'hr', 'img'])
+        ? `<${tag}${compiledProps} />`
+        : `<${tag}${compiledProps}></${tag}>`;
+}
+
+/**
  * Generates HTML source code directly from JSX
  *
  * @param {String} tag - JSX component name
@@ -71,7 +87,7 @@ export function compileHTML(tag, props, ...children) {
     ]);
 
     return children.length === 0
-        ? `<${filteredTag}${compileProps(props)} />`
+        ? compileSelfClosingTag(filteredTag, props)
         : `<${filteredTag}${compileProps(props)}>${children.map(render).join('')}</${filteredTag}>`;
 }
 

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -14,9 +14,7 @@ const fs = promisifyAll(require('fs'));
 export function getLocale() {
     const { RUNG_LOCALE } = process.env;
 
-    return resolve(RUNG_LOCALE
-        ? RUNG_LOCALE
-        : osLocale());
+    return resolve(RUNG_LOCALE ? RUNG_LOCALE : osLocale());
 }
 
 /**

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -13,7 +13,6 @@ const fs = promisifyAll(require('fs'));
  */
 export function getLocale() {
     const { RUNG_LOCALE } = process.env;
-
     return resolve(RUNG_LOCALE ? RUNG_LOCALE : osLocale());
 }
 

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -1,3 +1,4 @@
+import { resolve } from 'bluebird';
 import osLocale from 'os-locale';
 
 /**

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -1,5 +1,6 @@
 import { resolve } from 'bluebird';
 import osLocale from 'os-locale';
+import { curry, propOr } from 'ramda';
 
 /**
  * Returns the user locale. Firstly consider the env variable and, if it
@@ -14,3 +15,12 @@ export function getLocale() {
         ? resolve(RUNG_LOCALE)
         : osLocale();
 }
+
+/**
+ * Translates a string or fallback to the key
+ *
+ * @param {Object} map - Object containing extension strings
+ * @param {String} key - Key to search in hashmap
+ * @return {String}
+ */
+export const translator = curry((map, key) => propOr(key, key, map));

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -1,0 +1,15 @@
+import osLocale from 'os-locale';
+
+/**
+ * Returns the user locale. Firstly consider the env variable and, if it
+ * doesn't exist, consider machine's locale
+ *
+ * @return {Promise}
+ */
+export function getLocale() {
+    const { RUNG_LOCALE } = process.env;
+
+    return RUNG_LOCALE
+        ? resolve(RUNG_LOCALE)
+        : osLocale();
+}

--- a/src/packages.txt
+++ b/src/packages.txt
@@ -1,8 +1,0 @@
-ramda
-bluebird
-superagent
-superagent-promise
-rung-sdk
-moment
-tracking-correios
-yql

--- a/src/run.js
+++ b/src/run.js
@@ -5,6 +5,7 @@ import { runAndGetAlerts, getProperties } from './vm';
 import { ask } from './input';
 import { compileES6 } from './compiler';
 import { read } from './db';
+import { getLocaleStrings } from './i18n';
 
 export const readFile = promisify(fs.readFile);
 
@@ -16,12 +17,12 @@ export function compileSourceFile({ main }) {
 export default function run() {
     return readFile('package.json', 'utf-8')
         .then(JSON.parse)
-        .then(json => all([json.name, compileSourceFile(json), read(json.name)]))
-        .spread((name, source, db) => getProperties({ name, source })
+        .then(json => all([json.name, compileSourceFile(json), read(json.name), getLocaleStrings()]))
+        .spread((name, source, db, strings) => getProperties({ name, source }, strings)
             .then(prop('params'))
             .then(ask)
             .then(mergeAll)
-            .then(params => runAndGetAlerts({ name, source }, { params, db })))
+            .then(params => runAndGetAlerts({ name, source }, { params, db }, strings)))
         .tap(console.log.bind(console));
 }
 

--- a/test/compiler.spec.js
+++ b/test/compiler.spec.js
@@ -91,5 +91,23 @@ describe('compiler.js', () => {
                     expect(result).to.equals('<div><b>1</b><b>2</b><b>3</b></div>');
                 });
         });
+
+        it('should differ self-closing tags', () => {
+            const source = compileES6(`
+                const component = (
+                    <div>
+                        <div id="foo" />
+                        <br />
+                    </div>
+                );
+
+                export default { extension: () => component };
+            `);
+
+            return runAndGetAlerts({ name: 'test-jsx-array', source }, {})
+                .then(result => {
+                    expect(result).to.equals('<div><div id="foo"></div><br /></div>');
+                });
+        });
     })
 });

--- a/test/i18n.spec.js
+++ b/test/i18n.spec.js
@@ -1,0 +1,13 @@
+import { expect } from 'chai';
+import { getLocale } from '../src/i18n';
+
+describe('i18n.js', () => {
+    describe('Locale', () => {
+        it.only('should get locale from machine', () => {
+            return getLocale()
+                .then(locale => {
+                    expect(locale).to.match(/[a-z]{2}_[A-Z]{2}/);
+                });
+        });
+    });
+});

--- a/test/i18n.spec.js
+++ b/test/i18n.spec.js
@@ -3,7 +3,7 @@ import { getLocale } from '../src/i18n';
 
 describe('i18n.js', () => {
     describe('Locale', () => {
-        it.only('should get locale from machine', () => {
+        it('should get locale from machine', () => {
             return getLocale()
                 .then(locale => {
                     expect(locale).to.match(/[a-z]{2}_[A-Z]{2}/);

--- a/test/i18n.spec.js
+++ b/test/i18n.spec.js
@@ -6,7 +6,7 @@ describe('i18n.js', () => {
         it('should get locale from machine', () => {
             return getLocale()
                 .then(locale => {
-                    expect(locale).to.match(/[a-z]{2}_[A-Z]{2}/);
+                    expect(locale).to.match(/^[a-z]{2}_([A-Z]{2,3})?$/);
                 });
         });
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2406,6 +2406,12 @@ md5-o-matic@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/md5-o-matic/-/md5-o-matic-0.1.1.tgz#822bccd65e117c514fab176b25945d54100a03c3"
 
+mem@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/mem/-/mem-1.1.0.tgz#5edd52b485ca1d900fe64895505399a0dfa45f76"
+  dependencies:
+    mimic-fn "^1.0.0"
+
 meow@^3.4.2:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/meow/-/meow-3.7.0.tgz#72cb668b425228290abbfa856892587308a801fb"
@@ -2462,6 +2468,10 @@ mime-types@^2.1.12, mime-types@~2.1.7:
 mime@^1.3.4:
   version "1.3.6"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.3.6.tgz#591d84d3653a6b0b4a3b9df8de5aa8108e72e5e0"
+
+mimic-fn@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.1.0.tgz#e667783d92e89dbd342818b5230b9d62a672ad18"
 
 minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.3:
   version "3.0.4"
@@ -2698,6 +2708,14 @@ os-locale@^1.4.0:
   resolved "https://registry.yarnpkg.com/os-locale/-/os-locale-1.4.0.tgz#20f9f17ae29ed345e8bde583b13d2009803c14d9"
   dependencies:
     lcid "^1.0.0"
+
+os-locale@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/os-locale/-/os-locale-2.0.0.tgz#15918ded510522b81ee7ae5a309d54f639fc39a4"
+  dependencies:
+    execa "^0.5.0"
+    lcid "^1.0.0"
+    mem "^1.1.0"
 
 os-tmpdir@^1.0.0, os-tmpdir@^1.0.1:
   version "1.0.2"


### PR DESCRIPTION
### What it does?

This pull-request implements support for i18n (translation) for extensions. 

### How it does?

There is a global function called `_`, which is signed by `String -> String`, receives a string (default in: `en_US`) and looks for a value in an in-memory _hashmap_ parsed from JSON files under `locales/*`. When the value for the key is not found, it returns the key itself.

You can also explicitly set your locale to test by setting an environment variable called `RUNG_LOCALE`, if you don't, `rung-cli` will get the language used in your system (`LC_MESSAGE`):

`env RUNG_LANGUAGE rung run`

### Can you show me an example?

**index.js**
```js
...
const params = {
    name: {
        type: String,
        description: _('What is your name?')
    }
};
...
```

**locales/zh_CN.json**
```json
{
  "What is your name?": "你叫什么名字？"
}
```

### How much overhead?

It is `O(1)`. When running, we receive the locale, try to find the JSON file for it, parse and keep it in memory, the `_` function is a partial `translator(Map<String, String>): String: String`, keeping the access linear.