### PR TITLE
Fix compilation when there are no locales

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rung-cli",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Command line interface for Rung",
   "main": "./dist/vm.js",
   "bin": {

--- a/src/build.js
+++ b/src/build.js
@@ -10,7 +10,9 @@ import {
     drop,
     equals,
     filter,
+    head,
     identity,
+    ifElse,
     join,
     map,
     mapObjIndexed,
@@ -24,7 +26,7 @@ import {
     test,
     tryCatch,
     type,
-    when,
+    unary,
     without
 } from 'ramda';
 import deepmerge from 'deepmerge';
@@ -83,7 +85,7 @@ function runInAllLocales(locales, source) {
     return all([['default', {}], ...locales].map(([locale, strings]) =>
         getProperties({ name: `precompile-${locale}`, source }, strings)
             .then(project(locale))))
-            .then(when(complement(propEq('length', 1)), deepmerge.all));
+            .then(ifElse(propEq('length', 1), head, unary(deepmerge.all)));
 }
 
 /**


### PR DESCRIPTION
The same error was happening on NT systems, but it wasn't because of the kernel. It was because the identity was set to be returned on the merge of the meta file when there was only one locale (default). We should be returning the head instead.

Kisses of light.