### PR TITLE
Modules considered <3

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "chai-fs": "^1.0.0",
     "chai-json-schema": "^1.4.0",
     "codecov": "^2.2.0",
+    "intercept-stdout": "^0.1.2",
     "mocha": "^3.4.2",
     "nyc": "^11.0.2",
     "xo": "^0.18.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rung-cli",
-  "version": "0.7.4",
+  "version": "0.8.0",
   "description": "Command line interface for Rung",
   "main": "./dist/vm.js",
   "bin": {

--- a/src/input.js
+++ b/src/input.js
@@ -74,7 +74,7 @@ export function IO() {
  * @param {IO} io
  * @param {Object} questions
  */
-function triggerWarnings(io, questions) {
+export function triggerWarnings(io, questions) {
     const getFieldWarnings = pipe(
         mapObjIndexed(both(has('default'), propEq('required', true))),
         toPairs);

--- a/src/module.js
+++ b/src/module.js
@@ -32,7 +32,7 @@ const getFileTuple = filename => readFile(filename, 'utf-8')
  *
  * @return {Promise}
  */
-export const findModules = () => fileMatching('*.{js,json}')
+export const findModules = () => fileMatching('{*,*/*}.{js,json}')
     .then(without('index.js'));
 
 /**

--- a/src/module.js
+++ b/src/module.js
@@ -11,6 +11,8 @@ import {
     over,
     pipe,
     propSatisfies,
+    reject as rejectWhere,
+    test,
     without
 } from 'ramda';
 import { compileES6 } from './compiler';
@@ -33,7 +35,8 @@ const getFileTuple = filename => readFile(filename, 'utf-8')
  * @return {Promise}
  */
 export const findModules = () => fileMatching('{*,*/*}.{js,json}')
-    .then(without('index.js'));
+    .then(without('index.js'))
+    .then(rejectWhere(test(/^node_modules(\/|\\)/)));
 
 /**
  * Compiles a list of JS or JSON modules

--- a/src/module.js
+++ b/src/module.js
@@ -71,7 +71,7 @@ export const evaluateModules = (vm, modules) => fromPairs(flatMap(([module, sour
     // JSON doesn't need to run on VM. We can directly parse it
 
     const convertToBytecode = cond([
-        [endsWith('.json'), () => ({ default: JSON.parse(source) })],
+        [endsWith('.json'), () => JSON.parse(source)],
         [endsWith('.js'), module => vm.run(source, module)],
         [T, module => {
             throw new Error(`Unknown file type for ${module}`);
@@ -79,7 +79,6 @@ export const evaluateModules = (vm, modules) => fromPairs(flatMap(([module, sour
     ]);
 
     const bytecode = convertToBytecode(module);
-
     return [
         [fullName, bytecode],
         [partialName, bytecode]

--- a/src/module.js
+++ b/src/module.js
@@ -9,7 +9,8 @@ import {
     lensIndex,
     over,
     pipe,
-    propSatisfies
+    propSatisfies,
+    without
 } from 'ramda';
 import { compileES6 } from './compiler';
 
@@ -30,7 +31,8 @@ const getFileTuple = filename => readFile(filename, 'utf-8')
  *
  * @return {Promise}
  */
-export const findModules = () => fileMatching('*.{js,json}');
+export const findModules = () => fileMatching('*.{js,json}')
+    .then(without('index.js'));
 
 /**
  * Compiles a list of JS or JSON modules
@@ -44,6 +46,37 @@ export function compileModules(modules) {
             [propSatisfies(endsWith('json'), 0), over(lensIndex(1), pipe(JSON.parse, JSON.stringify))],
             [propSatisfies(endsWith('js'), 0), over(lensIndex(1), compileES6)],
             [T, reject]
-        ]))
-        .then(fromPairs);
+        ]));
+}
+
+/**
+ * Finds and compiles all modules
+ *
+ * @return {Promise}
+ */
+export function findAndCompileModules() {
+    return findModules().then(compileModules);
+}
+
+/**
+ * Evaluates a list of pairs of modules. modules :: [(String, String)]
+ *
+ * @param {NodeVM} vm - Virtual machine instance to run
+ * @param {String[][]} modules pairs, with [name :: string, source :: string]
+ */
+export function evaluateModules(vm, modules) {
+    // TODO: Use flatMap instead, to allow multiple module names!
+    return fromPairs(modules.map(([module, source]) => {
+        const name = `./${module}`;
+        // JSON doesn't need to run on VM. We can directly parse it
+        if (endsWith('.json', module)) {
+            return [name, { default: JSON.parse(source) }];
+        }
+
+        if (endsWith('.js', module)) {
+            return [name, vm.run(source, module)];
+        }
+
+        throw new Error(`Unknown file type for ${module}`);
+    }));
 }

--- a/src/module.js
+++ b/src/module.js
@@ -35,7 +35,7 @@ const getFileTuple = filename => readFile(filename, 'utf-8')
  * @return {Promise}
  */
 export const findModules = () => fileMatching('{*,*/*}.{js,json}')
-    .then(without('index.js'))
+    .then(without(['index.js']))
     .then(rejectWhere(test(/^node_modules(\/|\\)/)));
 
 /**

--- a/src/run.js
+++ b/src/run.js
@@ -18,6 +18,7 @@ import { ask } from './input';
 import { compileES6 } from './compiler';
 import { read } from './db';
 import { getLocale, getLocaleStrings } from './i18n';
+import { findAndCompileModules } from './module';
 
 const user = { name: os.userInfo().username };
 
@@ -50,14 +51,14 @@ export default function run(args) {
     return readFile('package.json', 'utf-8')
         .then(JSON.parse)
         .then(json => all([json.name, compileIndex(), read(json.name),
-            getLocaleStrings(), getLocale()]))
-        .spread((name, source, db, strings, locale) => getProperties({ name, source }, strings)
+            getLocaleStrings(), findAndCompileModules(), getLocale()]))
+        .spread((name, source, db, strings, modules, locale) => getProperties({ name, source }, strings, modules)
             .then(prop('params'))
             .then(ask)
             .then(mergeAll)
             .tap(() => spinner.start())
             .then(params => runAndGetAlerts({ name, source },
-                { params, db, locale, user }, strings)))
+                { params, db, locale, user }, strings, modules)))
         .tap(() => spinner.stop(true))
         .tap(pipe(args.raw ? identity : tableView, console.log));
 }

--- a/src/vm.js
+++ b/src/vm.js
@@ -8,18 +8,16 @@ import {
 import { compileHTML } from './compiler';
 import { upsert } from './db';
 import { translator } from './i18n';
+import { evaluateModules } from './module';
 
 /**
- * Runs an extension on a virtualized environment and returns its result as
- * native JS data
+ * Returns an instance of the Rung virtual machine
  *
  * @author Marcelo Haskell Camargo
- * @param {String} name - The unique identifier to track the extension
- * @param {String} source - ES6 source to run
- * @param {Object} strings - Object containing the strings to translate
- * @return {Promise}
+ * @param {Object} translator - Map of strings to translate
+ * @return {NodeVM}
  */
-function runInSandbox(name, source, strings = {}) {
+function createVM(strings) {
     const vm = new NodeVM({
         require: {
             external: true
@@ -29,7 +27,28 @@ function runInSandbox(name, source, strings = {}) {
     vm.freeze(compileHTML, '__render__');
     vm.freeze(translator(strings), '_');
 
+    return vm;
+}
+
+/**
+ * Runs an extension on a virtualized environment and returns its result as
+ * native JS data
+ *
+ * @author Marcelo Haskell Camargo
+ * @param {String} name - The unique identifier to track the extension
+ * @param {String} source - ES6 source to run
+ * @param {Object} strings - Object containing the strings to translate
+ * @param {String[][]} modules - Map of modules with [filename, source]
+ * @return {Promise}
+ */
+function runInSandbox(name, source, strings = {}, modules = []) {
     const evaluate = tryCatch(() => {
+        const vm = createVM(strings);
+
+        // Pre-evaluate and inject in vm all necessary modules
+        vm.options.require.mock = evaluateModules(vm, modules);
+
+        // Run with all modules! :)
         const result = vm.run(source, `${name}.js`);
         return resolve(propOr(result, 'default', result));
     }, reject);
@@ -43,10 +62,11 @@ function runInSandbox(name, source, strings = {}) {
  * @author Marcelo Haskell Camargo
  * @param {Object} extension - Must contain name and source
  * @param {Object} strings - Object with strings to translate
+ * @param {String[][]} modules - Object with modules name and source
  * @return {Promise}
  */
-export function getProperties(extension, strings) {
-    return runInSandbox(extension.name, extension.source, strings)
+export function getProperties(extension, strings, modules) {
+    return runInSandbox(extension.name, extension.source, strings, modules)
         .then(propOr({}, 'config'));
 }
 
@@ -58,10 +78,11 @@ export function getProperties(extension, strings) {
  * @param {Object} extension - Object containing name and source
  * @param {Object} context - Context to pass to the main function
  * @param {Object} strings - Object with strings to translate
+ * @param {String[][]} modules - Modules with [filename, source]
  * @return {Promise}
  */
-export function runAndGetAlerts(extension, context, strings) {
-    return runInSandbox(extension.name, extension.source, strings)
+export function runAndGetAlerts(extension, context, strings, modules) {
+    return runInSandbox(extension.name, extension.source, strings, modules)
         .then(app => {
             const runExtension = () => new Promise((resolve, reject) => {
                 if (type(app.extension) !== 'Function') {

--- a/src/vm.js
+++ b/src/vm.js
@@ -17,7 +17,7 @@ import { evaluateModules } from './module';
  * @param {Object} translator - Map of strings to translate
  * @return {NodeVM}
  */
-function createVM(strings) {
+export function createVM(strings) {
     const vm = new NodeVM({
         require: {
             external: true

--- a/test/input.spec.js
+++ b/test/input.spec.js
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
-import { resolveValue } from '../src/input';
+import intercept from 'intercept-stdout';
+import { IO, resolveValue, triggerWarnings } from '../src/input';
 import { String as Text } from '../src/types';
 import { compileES6 } from '../src/compiler';
 
@@ -18,6 +19,19 @@ describe('input.js', () => {
         it('should accept the default value of a string', () => {
             const value = resolveValue('', Text, 'alaska', false);
             expect(value).to.equals('alaska');
+        });
+    });
+
+    describe('Warnings', () => {
+        it('should trigger a warning when has named parameter language', () => {
+            let result = '';
+            const stopReading = intercept(text => result += text);
+            const io = IO();
+            triggerWarnings(io, { language: {} })
+                .then(() => {
+                    stopReading();
+                    expect(result).to.match(/Warning: don't use context.params.language/);
+                });
         });
     });
 });

--- a/test/module.spec.js
+++ b/test/module.spec.js
@@ -7,7 +7,6 @@ describe('module.js', () => {
             return findModules()
                 .then(files => {
                     expect(files).to.be.an('array');
-                    expect(files).to.have.lengthOf(41);
                 });
         });
 

--- a/test/module.spec.js
+++ b/test/module.spec.js
@@ -14,16 +14,15 @@ describe('module.js', () => {
         it('should correctly compile a JSON module', () => {
             return compileModules(['package.json'])
                 .then(compiledFiles => {
-                    expect(compiledFiles).to.be.an('object');
-                    expect(compiledFiles).to.have.property('package.json');
-                    expect(() => JSON.parse(compiledFiles['package.json'])).to.not.throw(Error);
+                    expect(compiledFiles).to.be.an('array');
+                    expect(compiledFiles).to.have.length(1);
                 });
         });
 
         it('should correctly compile a JS module', () => {
             return compileModules(['./test/module.spec.js', './test/build.spec.js'])
                 .then(compiledFiles => {
-                    expect(compiledFiles).to.be.an('object');
+                    expect(compiledFiles).to.be.an('array');
                 });
         });
     });

--- a/test/module.spec.js
+++ b/test/module.spec.js
@@ -7,7 +7,7 @@ describe('module.js', () => {
             return findModules()
                 .then(files => {
                     expect(files).to.be.an('array');
-                    expect(files).to.have.lengthOf(1);
+                    expect(files).to.have.lengthOf(41);
                 });
         });
 

--- a/test/module.spec.js
+++ b/test/module.spec.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { findModules, compileModules } from '../src/module';
+import { findModules, compileModules, findAndCompileModules } from '../src/module';
 
 describe('module.js', () => {
     describe('Module compilation', () => {
@@ -24,5 +24,12 @@ describe('module.js', () => {
                     expect(compiledFiles).to.be.an('array');
                 });
         });
+
+        it('should bootstrap the rung-cli project!!!', () => {
+            return findAndCompileModules()
+                .then(results => {
+                    expect(results).to.be.an('array');
+                });
+        }).timeout(40000);
     });
 });

--- a/test/module.spec.js
+++ b/test/module.spec.js
@@ -1,5 +1,11 @@
 import { expect } from 'chai';
-import { findModules, compileModules, findAndCompileModules } from '../src/module';
+import {
+    compileModules,
+    evaluateModules,
+    findAndCompileModules ,
+    findModules
+} from '../src/module';
+import { createVM } from '../src/vm';
 
 describe('module.js', () => {
     describe('Module compilation', () => {
@@ -30,6 +36,28 @@ describe('module.js', () => {
                 .then(results => {
                     expect(results).to.be.an('array');
                 });
-        }).timeout(40000);
+        }).timeout(20000);
+
+        it('should compile and evaluate modules', () => {
+            const modules = [
+                ['drag-queen.json', JSON.stringify({
+                    alaska: 1,
+                    courtney: 2
+                })],
+                ['workaround.js', `
+                    module.exports = 42;
+                `]
+            ];
+
+            const vm = createVM({});
+            const result = evaluateModules(vm, modules);
+            expect(result).to.be.an('object');
+            expect(result).to.have.property('./drag-queen.json');
+            expect(result).to.have.property('./drag-queen');
+            expect(result).to.have.property('./workaround.js');
+            expect(result).to.have.property('./workaround');
+            expect(result).property('./workaround').to.equals(42);
+            expect(result).property('./drag-queen').to.have.property('alaska');
+        });
     });
 });

--- a/test/publish.spec.js
+++ b/test/publish.spec.js
@@ -26,6 +26,6 @@ describe('publish.js', () => {
                     return stream.once('data');
                 })
                 .finally(stream.close);
-        }).timeout(10000);
+        }).timeout(15000);
     });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -881,7 +881,7 @@ cli-spinner@^0.2.6:
   version "0.2.6"
   resolved "https://registry.yarnpkg.com/cli-spinner/-/cli-spinner-0.2.6.tgz#8a59703324e93a908f6e601e4e74f5b85b371e5c"
 
-cli-table@^0.3.1:
+cli-table@0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/cli-table/-/cli-table-0.3.1.tgz#f53b05266a8b1a0b934b3d0821e6e2dc5914ae23"
   dependencies:
@@ -1928,6 +1928,12 @@ inquirer@^0.12.0:
     strip-ansi "^3.0.0"
     through "^2.3.6"
 
+intercept-stdout@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/intercept-stdout/-/intercept-stdout-0.1.2.tgz#126abf1fae6c509a428a98c61a631559042ae9fd"
+  dependencies:
+    lodash.toarray "^3.0.0"
+
 interpret@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.0.3.tgz#cbc35c62eeee73f19ab7b10a801511401afc0f90"
@@ -2337,6 +2343,10 @@ locate-path@^2.0.0:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
 
+lodash._arraycopy@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz#76e7b7c1f1fb92547374878a562ed06a3e50f6e1"
+
 lodash._baseassign@^3.0.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz#8c38a099500f215ad09e59f1722fd0c52bfe0a4e"
@@ -2351,6 +2361,10 @@ lodash._basecopy@^3.0.0:
 lodash._basecreate@^3.0.0:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz#1bc661614daa7fc311b7d03bf16806a0213cf821"
+
+lodash._basevalues@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz#5b775762802bde3d3297503e26300820fdf661b7"
 
 lodash._getnative@^3.0.0:
   version "3.9.1"
@@ -2427,6 +2441,14 @@ lodash.keys@^3.0.0:
 lodash.snakecase@^4.0.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz#39d714a35357147837aefd64b5dcbb16becd8f8d"
+
+lodash.toarray@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/lodash.toarray/-/lodash.toarray-3.0.2.tgz#2b204f0fa4f51c285c6f00c81d1cea5a23041179"
+  dependencies:
+    lodash._arraycopy "^3.0.0"
+    lodash._basevalues "^3.0.0"
+    lodash.keys "^3.0.0"
 
 lodash.upperfirst@^4.2.0:
   version "4.3.1"


### PR DESCRIPTION
This pull-request implements a module system for CLI module and dynamic bytecode compilation. Internal modules can only be imported from `index.js` file.

### Import

- [x] JSON files
- [x] JS files

### Features

- [x] Import omitting extension
- [x] Import submodules

The previous functions to run the source now can receive a 4th parameter of type `[(String, String)]`, which denotes module name name and compiled source representation. Before running the main file, the modules are precompiled and injected in the same virtual machine instance. This is a subset of ES6 module system (CommonJS), the only restriction beside it is that modules don't support cyclic references and, for obvious performance reasons, only the main file can call internal modules.

Good day.
![](https://i.ytimg.com/vi/Yj7ja6BANLM/maxresdefault.jpg)