### PR TITLE
Don't compile node modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rung-cli",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Command line interface for Rung",
   "main": "./dist/vm.js",
   "bin": {

--- a/src/build.js
+++ b/src/build.js
@@ -164,7 +164,7 @@ function filterFiles(files) {
         .then(({ code, modules }) =>
             all(modules.map(getQualifiedName))
                 .map(unary(path.join))
-                .then(union(files))
+                .then(union(without(['node_modules'], files)))
                 .then(files => ({ code, files })));
 }
 

--- a/test/data/hello-world/index.js
+++ b/test/data/hello-world/index.js
@@ -1,6 +1,6 @@
 import { create } from 'rung-sdk';
 import { String as Text } from 'rung-sdk/dist/types';
-import world from './world.js';
+import world from './sub/world.js';
 
 function main(context) {
     const { name } = context.params;

--- a/test/data/hello-world/sub/world.js
+++ b/test/data/hello-world/sub/world.js
@@ -1,0 +1,1 @@
+export default 'world';

--- a/test/data/hello-world/world.js
+++ b/test/data/hello-world/world.js
@@ -1,1 +1,0 @@
-export default 'world';


### PR DESCRIPTION
Before, the folder `node_modules` was being fully compiled into the Rung binary!
Well, this solves the bug, but at least we know that our VM and compiler are able to work in this scale.