### PR TITLE
Types for Calendar and AutoComplete

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rung-cli",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Command line interface for Rung",
   "main": "./dist/vm.js",
   "bin": {

--- a/src/types.js
+++ b/src/types.js
@@ -77,6 +77,7 @@ export const valueOrNothing = {
         return isNaN(money) ? Nothing() : Just(money);
     },
     String: Just,
+    AutoComplete: Just,
     Color: input => isHexColor(input) ? Just(input) : Nothing(),
     Email: input => isEmail(input) ? Just(input) : Nothing(),
     Checkbox: input => {

--- a/src/types.js
+++ b/src/types.js
@@ -59,7 +59,7 @@ export const valueOrNothing = {
         return isNaN(doubleValue) ? Nothing() : Just(doubleValue);
     },
     DateTime: input => {
-        const date = new Date(input);
+        const date = new JSDate(input);
         return isNaN(date.getMilliseconds()) ? Nothing() : Just(date);
     },
     Natural: input => {

--- a/src/types.js
+++ b/src/types.js
@@ -12,6 +12,9 @@ import {
 import { Just, Nothing } from 'data.maybe';
 import { isEmail, isHexColor, isURL } from 'validator';
 
+// Alias for JS Date, because we reuse the name
+const JSDate = Date;
+
 export const Integer = { name: 'Integer' };
 export const Double = { name: 'Double' };
 export const DateTime = { name: 'DateTime' };
@@ -98,7 +101,7 @@ export const valueOrNothing = {
     },
     Date: input => {
         // Default JS date constructor because MomentJS sucks for validation
-        const date = new Date(input);
+        const date = new JSDate(input);
         return date.toString() === 'Invalid Date'
             ? Nothing()
             : Just(date);

--- a/src/types.js
+++ b/src/types.js
@@ -12,9 +12,6 @@ import {
 import { Just, Nothing } from 'data.maybe';
 import { isEmail, isHexColor, isURL } from 'validator';
 
-// Alias for JS Date, because we reuse the name
-const JSDate = Date;
-
 export const Integer = { name: 'Integer' };
 export const Double = { name: 'Double' };
 export const DateTime = { name: 'DateTime' };
@@ -30,7 +27,7 @@ export const Checkbox = { name: 'Checkbox' };
 export const OneOf = values => ({ name: 'OneOf', values });
 export const Url = { name: 'Url' };
 export const IntegerMultiRange = (from, to) => ({ name: 'IntegerMultiRange', from, to });
-export const Date = { name: 'Date' };
+export const Calendar = { name: 'Calendar' };
 export const AutoComplete = { name: 'AutoComplete' };
 
 /**
@@ -59,7 +56,7 @@ export const valueOrNothing = {
         return isNaN(doubleValue) ? Nothing() : Just(doubleValue);
     },
     DateTime: input => {
-        const date = new JSDate(input);
+        const date = new Date(input);
         return isNaN(date.getMilliseconds()) ? Nothing() : Just(date);
     },
     Natural: input => {
@@ -99,9 +96,9 @@ export const valueOrNothing = {
 
         return Just([left, right]);
     },
-    Date: input => {
+    Calendar: input => {
         // Default JS date constructor because MomentJS sucks for validation
-        const date = new JSDate(input);
+        const date = new Date(input);
         return date.toString() === 'Invalid Date'
             ? Nothing()
             : Just(date);

--- a/src/types.js
+++ b/src/types.js
@@ -92,6 +92,13 @@ export const valueOrNothing = {
         }
 
         return Just([left, right]);
+    },
+    Date: input => {
+        // Default JS date constructor because MomentJS sucks for validation
+        const date = new Date(input);
+        return date.toString() === 'Invalid Date'
+            ? Nothing()
+            : Just(date);
     }
 };
 

--- a/src/types.js
+++ b/src/types.js
@@ -27,6 +27,8 @@ export const Checkbox = { name: 'Checkbox' };
 export const OneOf = values => ({ name: 'OneOf', values });
 export const Url = { name: 'Url' };
 export const IntegerMultiRange = (from, to) => ({ name: 'IntegerMultiRange', from, to });
+export const Date = { name: 'Date' };
+export const AutoComplete = { name: 'AutoComplete' };
 
 /**
  * Returns the human-readable name of a type

--- a/test/data/hello-world/README.md
+++ b/test/data/hello-world/README.md
@@ -4,7 +4,7 @@
 
 [![Deploy to Rung](https://i.imgur.com/uijt57R.png)](https://app.rung.com.br/integration/hello-world/customize)
 
-![rung-cli 0.9.0](https://img.shields.io/badge/rung--cli-0.9.0-blue.svg?style=flat-square)
+![rung-cli 0.9.1](https://img.shields.io/badge/rung--cli-0.9.1-blue.svg?style=flat-square)
 ![hello-world 0.1.0](https://img.shields.io/badge/hello--world-0.1.0-green.svg?style=flat-square)
 
 Hello world example

--- a/test/types.spec.js
+++ b/test/types.spec.js
@@ -176,11 +176,11 @@ describe('types.js', () => {
             expect(invalid.get).to.throw(TypeError);
         });
 
-        it('should validate date', () => {
+        it('should validate a calendar', () => {
             const date = 'Thu Jul 27 2017 08:55:10 GMT-0300 (BRT)';
             const workaround = 'BELIEVE IN ME, I\'M A DATE!!!';
-            const valid = valueOrNothing.Date(date);
-            const invalid = valueOrNothing.Date(workaround);
+            const valid = valueOrNothing.Calendar(date);
+            const invalid = valueOrNothing.Calendar(workaround);
 
             const extracted = valid.get();
             expect(extracted).to.be.instanceOf(Date);

--- a/test/types.spec.js
+++ b/test/types.spec.js
@@ -6,7 +6,6 @@ import {
     IntegerRange,
     IntegerMultiRange,
     OneOf,
-    String as Text,
     cast,
     getTypeName,
     valueOrNothing
@@ -173,6 +172,17 @@ describe('types.js', () => {
             const valid = valueOrNothing.IntegerMultiRange('40 70', props);
             const invalid = valueOrNothing.IntegerMultiRange('-10 20', props);
             expect(valid.get()).to.deep.equals([40, 70]);
+            expect(invalid.get).to.throw(TypeError);
+        });
+
+        it('should validate date', () => {
+            const date = 'Thu Jul 27 2017 08:55:10 GMT-0300 (BRT)';
+            const workaround = 'BELIEVE IN ME, I\'M A DATE!!!';
+            const valid = valueOrNothing.Date(date);
+            const invalid = valueOrNothing.Date(workaround);
+
+            const extracted = valid.get();
+            expect(extracted).to.be.instanceOf(Date);
             expect(invalid.get).to.throw(TypeError);
         });
     });

--- a/test/types.spec.js
+++ b/test/types.spec.js
@@ -60,7 +60,7 @@ describe('types.js', () => {
             expect(name).to.equals('IntegerRange(10, 20)');
         });
 
-        it('should recognized DoubleRange(m, n)', () => {
+        it('should recognize DoubleRange(m, n)', () => {
             const name = getTypeName(DoubleRange(10, 20));
             expect(name).to.equals('DoubleRange(10, 20)');
         });

--- a/test/types.spec.js
+++ b/test/types.spec.js
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 import {
+    AutoComplete,
     Char,
     DoubleRange,
     Integer,
@@ -184,6 +185,10 @@ describe('types.js', () => {
             const extracted = valid.get();
             expect(extracted).to.be.instanceOf(Date);
             expect(invalid.get).to.throw(TypeError);
+        });
+
+        it('should have identity for autocomplete', () => {
+            expect(valueOrNothing.AutoComplete('...').get()).to.equals('...');
         });
     });
 


### PR DESCRIPTION
This pull-request does:

- Add `Calendar` type, using default JS constructor because `moment` has issues and side-effects for validating (for example, it'll spit warnings on the screen, ugly warnings while validating, instead of returning, and this makes IO tests break)
- Add `AutoComplete` type, which is a `String` with other name :smile: 
- Add test for the new types