### PR TITLE
Release 1.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,16 +121,7 @@
         "error",
         "before"
       ],
-      "import/no-dynamic-require": [
-        "off"
-      ],
       "new-cap": [
-        "off"
-      ],
-      "no-useless-call": [
-        "off"
-      ],
-      "no-template-curly-in-string": [
         "off"
       ]
     }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "test": "FAST_TEST=1 nyc mocha --compilers js:babel-core/register test/{unit,salete}/index.js",
     "test:travis": "nyc mocha --compilers js:babel-core/register test/{unit,salete}/index.js",
     "report-coverage": "nyc report --reporter=lcov > coverage.lcov && codecov",
-    "coverage": "nyc --reporter=html yarn test:travis"
+    "coverage": "nyc --reporter=html yarn test:travis",
+    "lines": "bash scripts/lines.sh"
   },
   "dependencies": {
     "babel-core": "^6.25.0",
@@ -32,7 +33,6 @@
     "cli-spinner": "^0.2.6",
     "cli-table": "0.3.1",
     "colors": "1.1.2",
-    "commander": "2.9.0",
     "dasherize": "^2.0.0",
     "deepmerge": "^1.3.2",
     "handlebars": "^4.0.10",
@@ -40,12 +40,10 @@
     "inquirer-chalk-pipe": "1.1.0",
     "inquirer-datepicker-prompt": "0.3.3",
     "jszip": "^3.1.3",
-    "moment": "^2.18.1",
     "os-locale": "^2.0.0",
     "prettyjson": "^1.2.1",
     "ramda": "^0.24.1",
     "rimraf": "2.6.1",
-    "rung-sdk": "1.0.7",
     "semver": "5.4.1",
     "superagent": "^3.5.0",
     "superagent-promise": "^1.1.0",
@@ -65,7 +63,6 @@
     "chai-json-schema": "1.5.0",
     "codecov": "^2.2.0",
     "concat-stream": "1.6.0",
-    "intercept-stdout": "^0.1.2",
     "json-server": "^0.12.0",
     "mocha": "^3.4.2",
     "nyc": "^11.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rung-cli",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Command line interface for Rung",
   "main": "./dist/vm.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rung-cli",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Command line interface for Rung",
   "main": "./dist/vm.js",
   "bin": {

--- a/scripts/lines.sh
+++ b/scripts/lines.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+echo '----------------------------'
+echo 'Lines of source code'
+echo '----------------------------'
+find src -name '*.js' | xargs wc -l
+
+echo '----------------------------'
+echo 'Lines of tests'
+echo '----------------------------'
+find test -name '*.js' | xargs wc -l

--- a/src/boilerplate.js
+++ b/src/boilerplate.js
@@ -59,6 +59,7 @@ const getDefaultName = cond([
 function askQuestions() {
     return request.get('https://app.rung.com.br/api/categories')
         .then(prop('body') & map(({ name, alias: value }) => ({ name, value })))
+        .catch(~[{ name: 'Miscellaneous', value: 'miscellaneous' }])
         .then(categories => [
             { name: 'name', message: 'Project name', default: getDefaultName(process.cwd()) },
             { name: 'version', message: 'Version', default: '1.0.0', validate: semver.valid & Boolean },

--- a/src/boilerplate.js
+++ b/src/boilerplate.js
@@ -53,7 +53,6 @@ const getDefaultName = cond([
 /**
  * Generate the answers from the stdin.
  *
- * @param {IO} io
  * @return {Promise}
  */
 function askQuestions() {

--- a/src/build.js
+++ b/src/build.js
@@ -1,6 +1,6 @@
 import path from 'path';
 import Zip from 'jszip';
-import Promise, { all, promisifyAll, resolve } from 'bluebird';
+import Promise, { all, promisifyAll, reject, resolve } from 'bluebird';
 import {
     complement,
     concat,
@@ -123,15 +123,14 @@ function precompile({ code, files }) {
  */
 function filterFiles(files) {
     const clearModule = replace(/^\.\//, '');
-    const missingFiles = without(files, requiredFiles);
-    const hasIcon = contains('icon.png', files);
-    const resources = hasIcon ? ['icon.png'] : [];
+    const resources = files | filter(test(/^((icon\.png)|(README(\.\w+)?\.md))$/));
+    const missing = without(files, requiredFiles);
 
-    if (missingFiles.length > 0) {
-        throw new Error(`missing ${missingFiles.join(', ')} from the project`);
+    if (missing.length > 0) {
+        return reject(Error(`missing ${missing.join(', ')} from the project`));
     }
 
-    if (!hasIcon) {
+    if (!contains('icon.png', files)) {
         emitWarning('compiling extension without providing an icon.png file');
     }
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,23 +1,25 @@
 #!/usr/bin/env node
-
 import yargs from 'yargs';
-import { emitError } from './input';
-import build from './build';
-import run from './run';
-import publish from './publish';
-import boilerplate from './boilerplate';
-import readme from './readme';
-import db from './db';
+import { concat, memoize } from 'ramda';
 
-const commands = {
-    build, run, publish, boilerplate, readme, db
-};
+/**
+ * Lazy loading and cache of an internal ES6 module
+ *
+ * @param {String} module - Module to evaluate
+ * @return {*}
+ */
+const getModule = memoize(concat('./') & require);
 
+/**
+ * Entry point of Rung CLI
+ *
+ * @param {Object} args
+ */
 function cli(args) {
     const { _: [command] } = args;
-    commands[command](args)
+    return getModule(command).default(args)
         .catch(err => {
-            emitError(err.message);
+            getModule('input').emitError(err.message);
             process.exit(1);
         });
 }

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 
 import yargs from 'yargs';
-import { cond } from 'ramda';
 import { emitError } from './input';
 import build from './build';
 import run from './run';
@@ -10,19 +9,13 @@ import boilerplate from './boilerplate';
 import readme from './readme';
 import db from './db';
 
-const commandEquals = value => ({ _: [command] }) => value === command;
-
-const executeCommand = cond([
-    [commandEquals('build'), build],
-    [commandEquals('run'), run],
-    [commandEquals('publish'), publish],
-    [commandEquals('boilerplate'), boilerplate],
-    [commandEquals('readme'), readme],
-    [commandEquals('db'), db]
-]);
+const commands = {
+    build, run, publish, boilerplate, readme, db
+};
 
 function cli(args) {
-    executeCommand(args)
+    const { _: [command] } = args;
+    commands[command](args)
         .catch(err => {
             emitError(err.message);
             process.exit(1);

--- a/src/compiler.js
+++ b/src/compiler.js
@@ -6,6 +6,7 @@ import {
     ifElse,
     join,
     map,
+    prop,
     toPairs,
     type,
     unary,

--- a/src/compiler.js
+++ b/src/compiler.js
@@ -6,7 +6,6 @@ import {
     ifElse,
     join,
     map,
-    prop,
     toPairs,
     type,
     unary,

--- a/src/input.js
+++ b/src/input.js
@@ -74,7 +74,12 @@ const components = {
     OneOf: ({ type }) => ({ type: 'list', choices: type.values }),
     String: ~({ type: 'input' }),
     Url: ~({ validate: validator.Url }),
-    Money: ~({ validate: validator.Money, filter: filter.Money })
+    Money: ~({ validate: validator.Money, filter: filter.Money }),
+    SelectBox: ({ type }) => ({
+        type: 'list',
+        choices: type.values
+            | toPairs
+            | map(([value, name]) => ({ name, value })) })
 };
 
 /**

--- a/src/types.js
+++ b/src/types.js
@@ -42,6 +42,7 @@ export const IntegerMultiRange = (from, to) => ({ name: 'IntegerMultiRange', fro
 export const Calendar = { name: 'Calendar' };
 export const AutoComplete = { name: 'AutoComplete' };
 export const Location = { name: 'Location' };
+export const SelectBox = values => ({ name: 'SelectBox', values });
 
 /**
  * Returns the human-readable name of a type
@@ -55,6 +56,7 @@ export const getTypeName = cond([
     [propEq('name', 'IntegerRange'), t => `IntegerRange(${t.from}, ${t.to})`],
     [propEq('name', 'DoubleRange'), t => `DoubleRange(${t.from}, ${t.to})`],
     [propEq('name', 'OneOf'), t => `OneOf([${t.values.join(', ')}])`],
+    [propEq('name', 'SelectBox'), t => `SelectBox(${JSON.stringify(t.values)})`],
     [propEq('name', 'IntegerMultiRange'), t => `IntegerMultiRange(${t.from}, ${t.to})`],
     [T, _.name]
 ]);

--- a/test/salete/boilerplate.feat.js
+++ b/test/salete/boilerplate.feat.js
@@ -24,7 +24,7 @@ export default () => {
                 expect('salete-hello-world').to.be.a.directory()
                     .with.files(['README.md', 'index.js', 'package.json']);
             });
-    }).timeout(keepCalm(30));
+    }).timeout(keepCalm(60));
 
     it('should raise error when the folder of the project already exists', () => {
         return work(salete)

--- a/test/salete/boilerplate.feat.js
+++ b/test/salete/boilerplate.feat.js
@@ -17,7 +17,7 @@ const salete = {
 };
 
 export default () => {
-    it.only('should create a default project boilerplate to work on', () => {
+    it('should create a default project boilerplate to work on', () => {
         return work(salete)
             .tap(output => {
                 expect(output).to.contain('project generated');

--- a/test/salete/boilerplate.feat.js
+++ b/test/salete/boilerplate.feat.js
@@ -17,7 +17,7 @@ const salete = {
 };
 
 export default () => {
-    it('should create a default project boilerplate to work on', () => {
+    it.only('should create a default project boilerplate to work on', () => {
         return work(salete)
             .tap(output => {
                 expect(output).to.contain('project generated');

--- a/test/salete/build.feat.js
+++ b/test/salete/build.feat.js
@@ -31,7 +31,7 @@ const putSomeIcon = ~request.get('http://www.randomkittengenerator.com/cats/rota
 export default () => {
     before(~process.chdir('salete-hello-world'));
 
-    it.only('should compile the generated boilerplate', () => {
+    it('should compile the generated boilerplate', () => {
         return work(npm)
             .then(() => {
                 void expect('node_modules').to.be.a.directory().and.not.empty;

--- a/test/salete/build.feat.js
+++ b/test/salete/build.feat.js
@@ -1,8 +1,10 @@
 import process from 'process';
 import { expect } from 'chai';
-import { split } from 'ramda';
+import { keys, prop, split } from 'ramda';
+import JSZip from 'jszip';
 import work, {
     createFile,
+    readFile,
     createFolder,
     keepCalm,
     renameFile,
@@ -19,13 +21,17 @@ const compile = {
     does: [keepCalm(30)]
 };
 
+const zipInfo = path => readFile(path)
+    .then(new JSZip().loadAsync(_))
+    .then(prop('files') & keys);
+
 const putSomeIcon = ~request.get('http://www.randomkittengenerator.com/cats/rotator.php')
     .then(({ body }) => createFile('icon.png', body));
 
 export default () => {
     before(~process.chdir('salete-hello-world'));
 
-    it('should compile the generated boilerplate', () => {
+    it.only('should compile the generated boilerplate', () => {
         return work(npm)
             .then(() => {
                 void expect('node_modules').to.be.a.directory().and.not.empty;
@@ -36,6 +42,10 @@ export default () => {
                 expect(warning).to.contain('compiling extension without providing an icon.png file');
                 expect(success).to.contain('Rung extension compilation');
                 expect('salete-hello-world.rung').to.be.a.file();
+                return zipInfo('./salete-hello-world.rung');
+            })
+            .then(files => {
+                expect(files).to.contain('README.md');
             });
     }).timeout(keepCalm(90));
 

--- a/test/salete/input.feat.js
+++ b/test/salete/input.feat.js
@@ -31,7 +31,8 @@ const components = {
     integerMultiRange: { type: t.IntegerMultiRange(0, 50) },
     calendar: { type: t.Calendar },
     autocomplete: { type: t.AutoComplete },
-    location: { type: t.Location }
+    location: { type: t.Location },
+    selectBox: { type: t.SelectBox({ haskell: 'Haskell', erlang: 'Erlang' }) }
 } | map(assoc('description', 'question'));
 
 const actions = [
@@ -53,6 +54,7 @@ const actions = [
     press.ENTER, // Calendar
     type('strawberry' + press.ENTER), // Autocomplete
     type('New York' + press.ENTER), // Location
+    press.DOWN, press.ENTER, keepCalm(1), // SelectBox
     keepCalm(15)
 ];
 
@@ -99,6 +101,7 @@ export default () => {
                 expect(result.calendar).to.be.a('string');
                 expect(result.autocomplete).to.equals('strawberry');
                 expect(result.location).to.equals('New York');
+                expect(result.selectBox).to.equals('erlang');
             });
     }).timeout(keepCalm(90));
 

--- a/test/unit/types.spec.js
+++ b/test/unit/types.spec.js
@@ -9,6 +9,7 @@ export default () => {
             t.IntegerRange(10, 20),
             t.DoubleRange(10, 20),
             t.OneOf(['Scala', 'Haskell', 'Elixir']),
+            t.SelectBox({ haskell: 'Good', java: 'Bad' }),
             t.IntegerMultiRange(10, 20),
             t.Color
         ] | map(t.getTypeName)).to.deep.equals([
@@ -16,6 +17,7 @@ export default () => {
             'IntegerRange(10, 20)',
             'DoubleRange(10, 20)',
             'OneOf([Scala, Haskell, Elixir])',
+            'SelectBox({"haskell":"Good","java":"Bad"})',
             'IntegerMultiRange(10, 20)',
             'Color'
         ]);

--- a/test/unit/vm.spec.js
+++ b/test/unit/vm.spec.js
@@ -15,7 +15,7 @@ export default () => {
         });
 
         it('should get the alerts of a synchronous extension', () => {
-            const source = 'module.exports = { extension: ctx => ([\'Hello \' + ctx.name]) };';
+            const source = 'module.exports = { extension: ctx => ([\'Hello, \' + ctx.name + \'!\']) };';
 
             return runAndGetAlerts({ name: 'test-alerts', source }, { name: 'Marcelo' })
                 .then(alerts => {

--- a/test/unit/vm.spec.js
+++ b/test/unit/vm.spec.js
@@ -15,7 +15,7 @@ export default () => {
         });
 
         it('should get the alerts of a synchronous extension', () => {
-            const source = 'module.exports = { extension: ctx => ([`Hello, ${ctx.name}!`]) };';
+            const source = 'module.exports = { extension: ctx => ([\'Hello \' + ctx.name]) };';
 
             return runAndGetAlerts({ name: 'test-alerts', source }, { name: 'Marcelo' })
                 .then(alerts => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1405,10 +1405,6 @@ dasherize@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/dasherize/-/dasherize-2.0.0.tgz#6d809c9cd0cf7bb8952d80fc84fa13d47ddb1308"
 
-data.maybe@^1.2.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/data.maybe/-/data.maybe-1.2.2.tgz#f955e4b5572b2eb5047eab93d8bb3a1cc76a2dc3"
-
 dateformat@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-2.0.0.tgz#2743e3abb5c3fc2462e527dca445e04e9f4dee17"
@@ -2536,12 +2532,6 @@ inquirer@^3.2.3:
     strip-ansi "^4.0.0"
     through "^2.3.6"
 
-intercept-stdout@^0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/intercept-stdout/-/intercept-stdout-0.1.2.tgz#126abf1fae6c509a428a98c61a631559042ae9fd"
-  dependencies:
-    lodash.toarray "^3.0.0"
-
 interpret@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.0.3.tgz#cbc35c62eeee73f19ab7b10a801511401afc0f90"
@@ -3022,10 +3012,6 @@ lodash-id@^0.13.0:
   version "0.13.0"
   resolved "https://registry.yarnpkg.com/lodash-id/-/lodash-id-0.13.0.tgz#1b2086c24f004f07411bdb09b775072114bcddc6"
 
-lodash._arraycopy@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz#76e7b7c1f1fb92547374878a562ed06a3e50f6e1"
-
 lodash._baseassign@^3.0.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz#8c38a099500f215ad09e59f1722fd0c52bfe0a4e"
@@ -3040,10 +3026,6 @@ lodash._basecopy@^3.0.0:
 lodash._basecreate@^3.0.0:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz#1bc661614daa7fc311b7d03bf16806a0213cf821"
-
-lodash._basevalues@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz#5b775762802bde3d3297503e26300820fdf661b7"
 
 lodash._getnative@^3.0.0:
   version "3.9.1"
@@ -3120,14 +3102,6 @@ lodash.keys@^3.0.0:
 lodash.snakecase@^4.0.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz#39d714a35357147837aefd64b5dcbb16becd8f8d"
-
-lodash.toarray@^3.0.0:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/lodash.toarray/-/lodash.toarray-3.0.2.tgz#2b204f0fa4f51c285c6f00c81d1cea5a23041179"
-  dependencies:
-    lodash._arraycopy "^3.0.0"
-    lodash._basevalues "^3.0.0"
-    lodash.keys "^3.0.0"
 
 lodash.upperfirst@^4.2.0:
   version "4.3.1"
@@ -3334,10 +3308,6 @@ mocha@^3.4.2:
     lodash.create "3.1.1"
     mkdirp "0.5.1"
     supports-color "3.1.2"
-
-moment@^2.18.1:
-  version "2.18.1"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.18.1.tgz#c36193dd3ce1c2eed2adb7c802dbbc77a81b1c0f"
 
 morgan@^1.3.1:
   version "1.8.2"
@@ -3838,10 +3808,6 @@ ramda@>=0.15.0, ramda@^0.24.1:
   version "0.24.1"
   resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.24.1.tgz#c3b7755197f35b8dc3502228262c4c91ddb6b857"
 
-ramda@^0.23.0:
-  version "0.23.0"
-  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.23.0.tgz#ccd13fff73497a93974e3e86327bfd87bd6e8e2b"
-
 randomatic@^1.1.3:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/randomatic/-/randomatic-1.1.6.tgz#110dcabff397e9dcff7c0789ccc0a49adf1ec5bb"
@@ -4184,16 +4150,6 @@ run-async@^2.2.0:
   resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.3.0.tgz#0371ab4ae0bdd720d4166d7dfda64ff7a445a6c0"
   dependencies:
     is-promise "^2.1.0"
-
-rung-sdk@1.0.7:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/rung-sdk/-/rung-sdk-1.0.7.tgz#494118518aca8097d22b7c4fc8faf48c5e9b58bd"
-  dependencies:
-    bluebird "^3.4.7"
-    colors "^1.1.2"
-    data.maybe "^1.2.2"
-    ramda "^0.23.0"
-    validator "^6.2.1"
 
 rx-lite-aggregates@^4.0.8:
   version "4.0.8"
@@ -4780,10 +4736,6 @@ validate-npm-package-license@^3.0.1:
 validator@7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/validator/-/validator-7.0.0.tgz#c74deb8063512fac35547938e6f0b1504a282fd2"
-
-validator@^6.2.1:
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/validator/-/validator-6.3.0.tgz#47ce23ed8d4eaddfa9d4b8ef0071b6cf1078d7c8"
 
 vary@^1, vary@~1.1.1:
   version "1.1.1"


### PR DESCRIPTION
This pull-request provides the features and fixes for `rung-cli@1.0.2`.

- :white_check_mark: Release `SelectBox` component, which allows i18n
- :white_check_mark: Remove unused packages to make installation faster
- :white_check_mark: Add script to count lines of code and tests
- :white_check_mark: Fix bug for generated folder name on NT systems
- :white_check_mark: Optimise CLI dispatch table from `O(n)` selector to `O(1)`
- :white_check_mark: Embed `README.md` and `README.lang.md` files
- :white_check_mark: Keep tests with **100%** coverage
- :white_check_mark: Lazy loading for command modules
- :white_check_mark: Consider `miscellaneous` category when we have no Internet to fetch them

![Choque de monstro](https://media.tenor.com/images/58d6dd9ca688c9edfcef337c8aa39890/tenor.gif)