### PR TITLE
Support files in prompt

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rung-cli",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Command line interface for Rung",
   "main": "./dist/vm.js",
   "bin": {
@@ -39,6 +39,7 @@
     "inquirer-autocomplete-prompt": "0.11.1",
     "inquirer-chalk-pipe": "1.1.0",
     "inquirer-datepicker-prompt": "0.3.3",
+    "inquirer-file-path": "1.0.0",
     "jszip": "^3.1.3",
     "node-watch": "0.5.5",
     "opn": "5.1.0",

--- a/src/input.js
+++ b/src/input.js
@@ -150,9 +150,7 @@ const readFile = promisify(fs.readFile);
  */
 const openFiles = curry((fields, answers) => answers
     | mapObjIndexed((value, key) => value
-        | when(~contains(key, fields), filePath => filePath
-            | concat(process.cwd() + '/')
-            | readFile))
+        | when(~contains(key, fields), concat(process.cwd() + '/') & readFile))
     | props);
 
 /**

--- a/src/input.js
+++ b/src/input.js
@@ -149,8 +149,8 @@ const readFile = promisify(fs.readFile);
  * @return {Promise}
  */
 const openFiles = fields =>
-    mapObjIndexed((value, key) => value
-        | when(~contains(key, fields), concat(process.cwd() + '/') & readFile))
+    mapObjIndexed((value, param) => value
+        | when(~contains(param, fields), concat(process.cwd() + '/') & readFile))
     & props;
 
 /**

--- a/src/input.js
+++ b/src/input.js
@@ -148,10 +148,10 @@ const readFile = promisify(fs.readFile);
  * @param {Object} answers
  * @return {Promise}
  */
-const openFiles = curry((fields, answers) => answers
-    | mapObjIndexed((value, key) => value
+const openFiles = fields =>
+    mapObjIndexed((value, key) => value
         | when(~contains(key, fields), concat(process.cwd() + '/') & readFile))
-    | props);
+    & props;
 
 /**
  * Returns the pure JS values from received questions that will be answered

--- a/src/input.js
+++ b/src/input.js
@@ -1,3 +1,4 @@
+import process from 'process';
 import { resolve } from 'bluebird';
 import {
     T,
@@ -91,7 +92,8 @@ const components = {
         choices: objectToChoices(values) }),
     MultiSelectBox: ({ values }) => ({
         type: 'checkbox',
-        choices: objectToChoices(values) })
+        choices: objectToChoices(values) }),
+    File: ~{ type: 'filePath', basePath: process.cwd() }
 };
 
 /**
@@ -142,11 +144,13 @@ export function ask(questions) {
     const DatePickerPrompt = require('inquirer-datepicker-prompt');
     const ChalkPipe = require('inquirer-chalk-pipe');
     const AutocompletePrompt = require('inquirer-autocomplete-prompt');
+    const FilePath = require('inquirer-file-path');
 
     const prompt = createPromptModule();
     prompt.registerPrompt('datetime', DatePickerPrompt);
     prompt.registerPrompt('chalk-pipe', ChalkPipe);
     prompt.registerPrompt('autocomplete', AutocompletePrompt);
+    prompt.registerPrompt('filePath', FilePath);
     return getAutocompleteSources()
         .then(autocompleteSources => questions
             | toPairs

--- a/src/types.js
+++ b/src/types.js
@@ -46,6 +46,7 @@ export const AutoComplete = { name: 'AutoComplete' };
 export const Location = { name: 'Location' };
 export const SelectBox = values => ({ name: 'SelectBox', values });
 export const MultiSelectBox = values => ({ name: 'MultiSelectBox', values });
+export const File = ({ name: 'File' });
 
 /**
  * Returns the human-readable name of a type

--- a/yarn.lock
+++ b/yarn.lock
@@ -1111,7 +1111,7 @@ cli-boxes@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/cli-boxes/-/cli-boxes-1.0.0.tgz#4fa917c3e59c94a004cd61f8ee509da651687143"
 
-cli-cursor@^1.0.1:
+cli-cursor@^1.0.1, cli-cursor@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-1.0.2.tgz#64da3f7d56a54412e59794bd62dc35295e8f2987"
   dependencies:
@@ -1219,7 +1219,7 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
 
-concat-stream@1.6.0, concat-stream@^1.5.2:
+concat-stream@1.6.0, concat-stream@^1.4.7, concat-stream@^1.5.2:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.0.tgz#0aac662fd52be78964d5532f694784e70110acf7"
   dependencies:
@@ -1828,6 +1828,14 @@ extend@^3.0.0, extend@~3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444"
 
+external-editor@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-1.1.1.tgz#12d7b0db850f7ff7e7081baf4005700060c4600b"
+  dependencies:
+    extend "^3.0.0"
+    spawn-sync "^1.0.15"
+    tmp "^0.0.29"
+
 external-editor@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-2.0.4.tgz#1ed9199da9cbfe2ef2f7a31b2fde8b0d12368972"
@@ -1850,7 +1858,7 @@ fast-levenshtein@~2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
 
-figures@^1.3.5:
+figures@^1.3.5, figures@^1.4.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-1.7.0.tgz#cbe1e3affcf1cd44b80cadfed28dc793a9701d2e"
   dependencies:
@@ -2315,6 +2323,18 @@ inquirer-datepicker-prompt@0.3.3:
     lodash "^4.17.4"
     util "^0.10.3"
 
+inquirer-file-path@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/inquirer-file-path/-/inquirer-file-path-1.0.0.tgz#87626b5a774277a934880d2aa5061e0f510bee60"
+  dependencies:
+    chalk "^1.1.1"
+    cli-cursor "^1.0.2"
+    figures "^1.4.0"
+    inquirer "^1.1.3"
+    lodash "^3.10.1"
+    rx-lite "^4.0.8"
+    util "^0.10.3"
+
 inquirer@3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-3.1.1.tgz#87621c4fba4072f48a8dd71c9f9df6f100b2d534"
@@ -2348,6 +2368,25 @@ inquirer@^0.12.0:
     readline2 "^1.0.1"
     run-async "^0.1.0"
     rx-lite "^3.1.2"
+    string-width "^1.0.1"
+    strip-ansi "^3.0.0"
+    through "^2.3.6"
+
+inquirer@^1.1.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-1.2.3.tgz#4dec6f32f37ef7bb0b2ed3f1d1a5c3f545074918"
+  dependencies:
+    ansi-escapes "^1.1.0"
+    chalk "^1.0.0"
+    cli-cursor "^1.0.1"
+    cli-width "^2.0.0"
+    external-editor "^1.1.0"
+    figures "^1.3.5"
+    lodash "^4.3.0"
+    mute-stream "0.0.6"
+    pinkie-promise "^2.0.0"
+    run-async "^2.2.0"
+    rx "^4.1.0"
     string-width "^1.0.1"
     strip-ansi "^3.0.0"
     through "^2.3.6"
@@ -2933,6 +2972,10 @@ lodash.upperfirst@^4.2.0:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/lodash.upperfirst/-/lodash.upperfirst-4.3.1.tgz#1365edf431480481ef0d1c68957a5ed99d49f7ce"
 
+lodash@^3.10.1:
+  version "3.10.1"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
+
 lodash@^4.0.0, lodash@^4.13.1, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.3.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
@@ -3129,6 +3172,10 @@ mute-stream@0.0.5:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.5.tgz#8fbfabb0a98a253d3184331f9e8deb7372fac6c0"
 
+mute-stream@0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.6.tgz#48962b19e169fd1dfc240b3f1e7317627bbc47db"
+
 mute-stream@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
@@ -3323,6 +3370,10 @@ os-locale@^2.0.0:
     execa "^0.5.0"
     lcid "^1.0.0"
     mem "^1.1.0"
+
+os-shim@^0.1.2:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/os-shim/-/os-shim-0.1.3.tgz#6b62c3791cf7909ea35ed46e17658bb417cb3917"
 
 os-tmpdir@^1.0.0, os-tmpdir@^1.0.1, os-tmpdir@~1.0.1:
   version "1.0.2"
@@ -3889,6 +3940,10 @@ rx-lite@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-3.1.2.tgz#19ce502ca572665f3b647b10939f97fd1615f102"
 
+rx@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/rx/-/rx-4.1.0.tgz#a5f13ff79ef3b740fe30aa803fb09f98805d4782"
+
 safe-buffer@^5.0.1, safe-buffer@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.0.1.tgz#d263ca54696cd8a306b5ca6551e92de57918fbe7"
@@ -4024,6 +4079,13 @@ source-map@^0.4.4:
 source-map@^0.5.0, source-map@^0.5.3, source-map@^0.5.6, source-map@~0.5.1:
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412"
+
+spawn-sync@^1.0.15:
+  version "1.0.15"
+  resolved "https://registry.yarnpkg.com/spawn-sync/-/spawn-sync-1.0.15.tgz#b00799557eb7fb0c8376c29d44e8a1ea67e57476"
+  dependencies:
+    concat-stream "^1.4.7"
+    os-shim "^0.1.2"
 
 spawn-wrap@^1.3.7:
   version "1.3.8"
@@ -4232,6 +4294,12 @@ through@^2.3.6:
 timed-out@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/timed-out/-/timed-out-4.0.1.tgz#f32eacac5a175bea25d7fab565ab3ed8741ef56f"
+
+tmp@^0.0.29:
+  version "0.0.29"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.29.tgz#f25125ff0dd9da3ccb0c2dd371ee1288bb9128c0"
+  dependencies:
+    os-tmpdir "~1.0.1"
 
 tmp@^0.0.31:
   version "0.0.31"


### PR DESCRIPTION
This pull-request implements support for files and adds the `File` component.

The picker will list the files in the current directory and folders (and allows searching).
The field passed on context will have the `Buffer` of the provided file.

![2017-10-23-160418_438x123_scrot](https://user-images.githubusercontent.com/7553006/31905172-0d5ddb0c-b80c-11e7-9c3d-cd6413c15acd.png)

![2017-10-23-160538_437x190_scrot](https://user-images.githubusercontent.com/7553006/31905171-0d349bde-b80c-11e7-9589-7a6236b2498e.png)

![2017-10-23-160544_506x80_scrot](https://user-images.githubusercontent.com/7553006/31905170-0d0ca624-b80c-11e7-85e0-98ea7b94dd0d.png)




